### PR TITLE
K8S-952: Set isolated pip arguments matching octavia deployment flags

### DIFF
--- a/tasks/designate_install.yml
+++ b/tasks/designate_install.yml
@@ -40,7 +40,7 @@
     extra_args: >-
       {{ designate_developer_mode | ternary(pip_install_developer_constraints | default('--constraint /opt/developer-pip-constraints.txt'), '') }}
       {{ (pip_install_upper_constraints is defined) | ternary('--constraint ' + pip_install_upper_constraints | default(''),'') }}
-      {{ pip_install_options | default('') }}
+      {{ pip_install_options + ' --isolated' | default('--isolated') }}
   register: install_packages
   until: install_packages|success
   retries: 5
@@ -93,7 +93,7 @@
     extra_args: >-
       {{ designate_developer_mode | ternary(pip_install_developer_constraints | default('--constraint /opt/developer-pip-constraints.txt'), '') }}
       {{ (pip_install_upper_constraints is defined) | ternary('--constraint ' + pip_install_upper_constraints | default(''),'') }}
-      {{ pip_install_options | default('') }}
+      {{ pip_install_options + ' --isolated' | default('--isolated') }}
   register: install_packages
   until: install_packages|success
   retries: 5


### PR DESCRIPTION
Swap the pip arguments to be isolated matching the same logic in the octavia ansible tasks.